### PR TITLE
'fix-filter.php' rework

### DIFF
--- a/fix-filter.php
+++ b/fix-filter.php
@@ -1,14 +1,11 @@
 <?php
 
-require 'vendor/mustache/mustache/src/Mustache/Autoloader.php';
-Mustache_Autoloader::register();
-
 $globals = array();
 $globals['inFolder'] = "xml-in";
 $globals['outFolder'] = "xml-out";
 $globals['searchItems'] = array(
   'Bucheinband', 'Devise', 'Initiale', 'Inschrift', 'Recto', 'Titelblatt', 'Verso', 'Wappen', 
-  'Architekturzeichnung','Chronik', 'Entwurfszeichnung', 'Flugblatt', 'Gedenkblatt', 'Politische Karikatur', 'Presentationszeichnung', 'Probedruck', 'Vorzeichnung',
+  'Architekturzeichnung', 'Chronik', 'Entwurfszeichnung', 'Flugblatt', 'Gedenkblatt', 'Politische Karikatur', 'Presentationszeichnung', 'Probedruck', 'Vorzeichnung',
   'Buch', 'Einblatt', 'Frontispiz', 'Gebetbuch', 'I. Zustand', 'II. Zustand', 'III. Zustand', 'Illustriertes Buch', 'Karte', 'Serie', 'Skizzenbuch', 'Stammbuch',
   '1st state',
   '2nd state',
@@ -16,11 +13,17 @@ $globals['searchItems'] = array(
   'commemorative print'
 );
 
-$globals['template'] = '<term type="Descriptor" term="{{string}}"';
-
-function readFolder($folder)
+function readFolder(string $folder)
 {
     return glob($folder . "/*.xml");
+}
+
+function applyFunctionOnNodeRecursivly(callable $func, DOMNode $node, $depth = 0) {
+  call_user_func($func, $node, $depth);
+
+  for($i = $node->childNodes->length - 1; $i >= 0; $i -= 1) {
+    applyFunctionOnNodeRecursivly($func, $node->childNodes->item($i), $depth  + 1);
+  }
 }
 
 $files = readFolder($globals['inFolder']);
@@ -37,20 +40,36 @@ $input = intval(chop(readline("Command: ")));
 if($input == NULL){ exit; }
 
 $path = $files[$input-1];
-$xml = file_get_contents($path);
 
-$m = new Mustache_Engine;
-foreach($globals['searchItems'] as $searchItem){
-  $pattern =  preg_quote($m->render($globals['template'], array('string' => $searchItem)), '=');
-  $xml = preg_replace(
-    "=$pattern.*?\/term>=is",
-    '',
-    $xml
-  );
-}
+$dom = new DOMDocument();
+$dom->load($path);
+
+/* Remove nodes */
+applyFunctionOnNodeRecursivly(function($node) use ($globals) {
+  if (!$node->hasAttributes() || $node->nodeName !== 'term') {
+    return;
+  }
+
+  $termAttr = $node->attributes->getNamedItem('term');
+
+  if (is_null($termAttr)) {
+    return;
+  }
+
+  $termValue = $termAttr->value;
+
+  foreach($globals['searchItems'] as $searchItem) {
+    if (in_array($termValue, $globals['searchItems'])) {
+      $node->parentNode->removeChild($node);
+      break;
+    }
+  }
+}, $dom->documentElement);
 
 $filename = basename($path);
 $target = $globals['outFolder']. '/' . $filename;
-file_put_contents($target, $xml);
+$xmlOutput = str_replace('<?xml version="1.0"?>' . "\n", '', trim($dom->saveXML()));
+
+file_put_contents($target, $xmlOutput);
 
 print "\nFertig: $target\n\n";


### PR DESCRIPTION
Mit diesem PR wird für das `fix-filter.php`-Script auf DomDocument umgeschwenkt, um Elemente in einer DOM-Struktur handhaben zu können.

Aktuell werden folgende Aktionen auf die Thesaurus-Daten angewandt:
* Löschen von `term`-Elementen mit bestimmten `term`-Attributwerten (Filter, die aktuell nicht für Gemälde relevant sind)
* Sortierung von `term`-Elementen anhand des "dKult Term Identifiers" (in `alt-term`-Kindelement zu finden)

Der Code ist etwas quick'n'dirt, wird in Zukunft aber wahrscheinlich auch nicht viel weiter angefasst.